### PR TITLE
Add github action for build & publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Variables
+        id: vars
+        run:
+          echo ::set-output name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')
+          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
+          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
+          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+
+      - uses: docker/setup-qemu-action@v1
+        name: Set up QEMU
+
+      - uses: docker/setup-buildx-action@v1
+        name: Setup Docker Buildx
+
+      - uses: docker/build-push-action@v2
+        name: Build
+        with:
+          context: .
+          platforms: linux/amd64
+
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - uses: docker/build-push-action@v2
+        name: Push latest
+        if: github.ref == 'refs/heads/master'
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ steps.vars.REPOSITORY_NAME }}:latest
+          push: true
+
+      - uses: docker/build-push-action@v2
+        name: Push tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ steps.vars.REPOSITORY_NAME }}:${{ steps.vars.outputs.SOURCE_TAG }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM alpine:latest
 
 # Install kamikaze
 RUN set -exuo pipefail \
-  && apk add \
+  && apk --no-cache add \
     curl \
   && curl https://raw.githubusercontent.com/Enteee/kamikaze/master/install.sh | sh
 
 # Install tls-tofu
 RUN set -exuo pipefail \
-  && apk add \
+  && apk --no-cache add \
     openssl
 
 COPY tls-tofu.sh /


### PR DESCRIPTION
Also:
  - disbale apk cache usage

Fixes:
  - Small request, pin the postinstall task to a hash instead of branch name [1]

References:
  [1]: https://github.com/Enteee/tls-tofu/issues/1